### PR TITLE
Add support for Python 3.4/3.5 and PyPy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 sudo: false
 python:
     - 2.7
+    - pypy
+    - 3.4
+    - 3.5
 install:
     - python bootstrap.py
     - bin/buildout

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 0.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Python 3.4, Python 3.5 and PyPy.
 
 
 0.3.6 (2016-01-29)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -5,8 +5,8 @@ parts = devpython test
 [devpython]
 recipe = zc.recipe.egg
 interpreter = devpython
-eggs = z3c.autoinclude
+eggs = z3c.autoinclude[test]
 
 [test]
 recipe = zc.recipe.testrunner
-eggs = z3c.autoinclude
+eggs = z3c.autoinclude[test]

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,11 @@ from setuptools import setup, find_packages
 version = '0.3.7.dev0'
 __version__ = version
 
+TESTS_REQUIRE = [
+    "zc.buildout",
+    "zope.testing",
+]
+
 setup(
     name='z3c.autoinclude',
     version=__version__,
@@ -12,6 +17,11 @@ setup(
     classifiers=[
         "Framework :: Zope3",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.4"
+        "Programming Language :: Python :: 3.5"
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     keywords='',
     author='Zope Foundation and Contributors',
@@ -31,7 +41,10 @@ setup(
         'zope.schema',
         'zc.buildout',
     ],
-    extras_require={'test': ['zc.buildout', 'zope.testing']},
+    tests_require=TESTS_REQUIRE,
+    extras_require={
+        'test': TESTS_REQUIRE,
+    },
     entry_points="""
     [console_scripts]
     autoinclude-test = z3c.autoinclude.tests.tests:interactive_testing_env

--- a/src/z3c/autoinclude/__init__.py
+++ b/src/z3c/autoinclude/__init__.py
@@ -1,2 +1,3 @@
 #
-from dependency import package_includes
+from __future__ import absolute_import
+from .dependency import package_includes

--- a/src/z3c/autoinclude/api.py
+++ b/src/z3c/autoinclude/api.py
@@ -4,15 +4,15 @@ DEP_KEY = 'Z3C_AUTOINCLUDE_DEPENDENCIES_DISABLED'
 PLUGIN_KEY = 'Z3C_AUTOINCLUDE_PLUGINS_DISABLED'
 
 def dependencies_disabled():
-    return os.environ.has_key(DEP_KEY)
+    return DEP_KEY in os.environ
 def disable_dependencies():
     os.environ[DEP_KEY] = 'True'
 def enable_dependencies():
     del os.environ[DEP_KEY]
 
 def plugins_disabled():
-    return os.environ.has_key(PLUGIN_KEY)
+    return PLUGIN_KEY in os.environ
 def disable_plugins():
     os.environ[PLUGIN_KEY] = 'True'
-def enable_dependencies():
+def enable_plugins():
     del os.environ[PLUGIN_KEY]

--- a/src/z3c/autoinclude/dependency.py
+++ b/src/z3c/autoinclude/dependency.py
@@ -24,7 +24,7 @@ class DependencyFinder(DistributionManager):
             for dotted_name in dist_manager.dottedNames():
                 try:
                     module = resolve(dotted_name)
-                except ImportError, exc:
+                except ImportError as exc:
                     logging.getLogger("z3c.autoinclude").warn(
                         "resolve(%r) raised import error: %s" % (dotted_name, exc))
                     continue

--- a/src/z3c/autoinclude/dependency.txt
+++ b/src/z3c/autoinclude/dependency.txt
@@ -86,8 +86,8 @@ that it depends on that have ``configure.zcml`` or ``meta.zcml``.
 Note that the individual lists within ``includableInfo`` preserve the
 package order defined in ``setup.py``::
 
-    >>> list(sorted(list(a_include_finder.includableInfo(['configure.zcml', 'meta.zcml']).items())))
-    [('configure.zcml', ['b.c']), ('meta.zcml', ['z3c.autoinclude', 'testdirective'])]
+    >>> pprint(a_include_finder.includableInfo(['configure.zcml', 'meta.zcml']))
+    {'configure.zcml': ['b.c'], 'meta.zcml': ['z3c.autoinclude', 'testdirective']}
 
 For a nested namespace package with two siblings ``SiblingPackage``,
 we should get the same expected results. The sibling package

--- a/src/z3c/autoinclude/dependency.txt
+++ b/src/z3c/autoinclude/dependency.txt
@@ -34,7 +34,7 @@ We can adapt a distribution to a DependencyFinder::
     >>> from z3c.autoinclude.dependency import DependencyFinder
     >>> a_include_finder = DependencyFinder(a_dist)
     >>> b_include_finder = DependencyFinder(b_dist)
-    
+
     >>> import x.y.z
     >>> xyz_dist = distributionForPackage(x.y.z)
     >>> xyz_include_finder = DependencyFinder(xyz_dist)
@@ -86,8 +86,8 @@ that it depends on that have ``configure.zcml`` or ``meta.zcml``.
 Note that the individual lists within ``includableInfo`` preserve the
 package order defined in ``setup.py``::
 
-    >>> a_include_finder.includableInfo(['configure.zcml', 'meta.zcml'])
-    {'configure.zcml': ['b.c'], 'meta.zcml': ['z3c.autoinclude', 'testdirective']}
+    >>> list(sorted(list(a_include_finder.includableInfo(['configure.zcml', 'meta.zcml']).items())))
+    [('configure.zcml', ['b.c']), ('meta.zcml', ['z3c.autoinclude', 'testdirective'])]
 
 For a nested namespace package with two siblings ``SiblingPackage``,
 we should get the same expected results. The sibling package
@@ -126,7 +126,7 @@ order::
     >>> dummy = xmlconfig.file(resource_filename('a', 'configure.zcml'),
     ...                        package=a)
     >>> from testdirective.zcml import test_log
-    >>> pprint(test_log)
+    >>> pprint(test_log, width=30)
     [u'f.g meta has been loaded',
      u'f.h has been loaded',
      u'BCPackage has been loaded']

--- a/src/z3c/autoinclude/plugin.txt
+++ b/src/z3c/autoinclude/plugin.txt
@@ -4,7 +4,7 @@ Automatic inclusion of extension packages
 
 There is additional functionality for registering and autoincluding
 extension packages for a particular platform.
- 
+
 In this test environment, ``BasePackage`` provides the ``basepackage``
 module which we will treat as our platform.  ``FooPackage`` wants to
 broadcast itself as a plugin for ``basepackage`` and thereby register
@@ -74,7 +74,7 @@ should accurately reflect that the ``FooPackage`` ZCML has been loaded::
 
     >>> dummy = xmlconfig.file(resource_filename('basepackage', 'configure.zcml'),
     ...                        package=basepackage)
-    >>> pprint(test_log)
+    >>> test_log
     [u'foo has been loaded']
 
 ``base2`` is a namespace package. ``base2.plug`` is a package that
@@ -89,5 +89,5 @@ defines a plugin for base2; it extends ``base2``s namespace.
     >>> filename = resource_filename(req, os.path.join('base2', 'configure.zcml'))
 
     >>> dummy = xmlconfig.file(filename, package=base2)
-    >>> pprint(test_log)
+    >>> test_log
     [u'base2.plug has been loaded']

--- a/src/z3c/autoinclude/tests/tests.py
+++ b/src/z3c/autoinclude/tests/tests.py
@@ -1,11 +1,14 @@
+import re
 import os
 import doctest
 import unittest
 
 from zc.buildout import testing
+from zope.testing import renormalizing
+
 
 projects_dir = os.path.dirname(__file__)
-    
+
 # this is the list of test packages that we'll temporarily install
 # for the duration of the tests; you MUST add your test package name
 # to this list if you want it to be available for import in doctests!
@@ -52,7 +55,7 @@ def testSetUp(test):
     install test packages so that they can be imported
     and their egg info examined in test runs
     """
-    
+
     testing.buildoutSetUp(test)
     import tempfile
     target_dir = tempfile.mkdtemp('.z3c.autoinclude.test-installs')
@@ -68,12 +71,19 @@ def testTearDown(test):
 
 IGNORECASE = doctest.register_optionflag('IGNORECASE')
 
-class IgnoreCaseChecker(doctest.OutputChecker):
+class IgnoreCaseChecker(renormalizing.RENormalizing, object):
+    def __init__(self):
+        super(IgnoreCaseChecker, self).__init__([
+            # Python 3 drops the u'' prefix on unicode strings
+            (re.compile(r"u('[^']*')"), r"\1"),
+            # Python 3 adds module name to exceptions
+            (re.compile("pkg_resources.DistributionNotFound"), r"DistributionNotFound"),
+        ])
     def check_output(self, want, got, optionflags):
         if optionflags & IGNORECASE:
             want, got = want.lower(), got.lower()
             #print repr(want), repr(got), optionflags, IGNORECASE
-        return doctest.OutputChecker.check_output(self, want, got, optionflags)
+        return super(IgnoreCaseChecker, self).check_output(want, got, optionflags)
 
 def test_suite():
 

--- a/src/z3c/autoinclude/utils.py
+++ b/src/z3c/autoinclude/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import os
 from pkg_resources import find_distributions
 from pprint import pformat
@@ -92,10 +94,18 @@ def distributionForDottedName(package_dottedname):
         raise LookupError("No distributions found for package `%s`; are you sure it is importable?" % package_dottedname)
 
     if len(valid_dists_for_package) > 1:
-        non_namespaced_dists = [x for x in valid_dists_for_package if x[1] is 0]
+        non_namespaced_dists = [x for x in valid_dists_for_package if len(x[1]) is 0]
         if len(non_namespaced_dists) == 0:
-            # if we only have namespace packages at this point, 'foo.bar' and 'foo.baz', while looking for 'foo',
-            # we can just select the first because the choice has no effect
+            # if we only have namespace packages at this point,
+            # 'foo.bar' and 'foo.baz', while looking for 'foo', we can
+            # just select the first because the choice has no effect.
+            # However, if possible, we prefer to select the one that matches the package name
+            # if it's the "root" namespace
+            if '.' not in package_dottedname:
+                for dist, _ in valid_dists_for_package:
+                    if dist.project_name == package_dottedname:
+                        return dist
+
             return valid_dists_for_package[0][0]
 
         valid_dists_for_package = non_namespaced_dists ### if we have packages 'foo', 'foo.bar', and 'foo.baz', the correct one is 'foo'.

--- a/src/z3c/autoinclude/utils.py
+++ b/src/z3c/autoinclude/utils.py
@@ -94,7 +94,9 @@ def distributionForDottedName(package_dottedname):
         raise LookupError("No distributions found for package `%s`; are you sure it is importable?" % package_dottedname)
 
     if len(valid_dists_for_package) > 1:
-        non_namespaced_dists = [x for x in valid_dists_for_package if len(x[1]) is 0]
+        non_namespaced_dists = [(dist, ns_packages)
+                                for dist, ns_packages
+                                in valid_dists_for_package if len(ns_packages) == 0]
         if len(non_namespaced_dists) == 0:
             # if we only have namespace packages at this point,
             # 'foo.bar' and 'foo.baz', while looking for 'foo', we can
@@ -105,6 +107,11 @@ def distributionForDottedName(package_dottedname):
                 for dist, _ in valid_dists_for_package:
                     if dist.project_name == package_dottedname:
                         return dist
+
+            # Otherwise, to be deterministic (because the order depends on both sys.path
+            # and `find_distributions`) we will sort them by project_name and return
+            # the first value.
+            valid_dists_for_package.sort(key=lambda dist_ns: dist_ns[0].project_name)
 
             return valid_dists_for_package[0][0]
 

--- a/src/z3c/autoinclude/utils.py
+++ b/src/z3c/autoinclude/utils.py
@@ -72,8 +72,8 @@ def distributionForPackage(package):
 def distributionForDottedName(package_dottedname):
     """
     This function is ugly and probably slow. It needs to be heavily
-    commented, it needs narrative doctests, and it needs some broad
-    explanation. It fails in some namespace cases (see utils.txt).
+    commented, it needs narrative doctests, it needs some broad
+    explanation, and it is arbitrary in some namespace cases.
     Then it needs to be profiled.
     """
     valid_dists_for_package = []

--- a/src/z3c/autoinclude/utils.py
+++ b/src/z3c/autoinclude/utils.py
@@ -39,7 +39,7 @@ class ZCMLInfo(dict):
         for zcml_group in zcml_to_look_for:
             self[zcml_group] = []
 
-    
+
 def subpackageDottedNames(package_path, ns_dottedname=None):
     # we do not look for subpackages in zipped eggs
     if not isUnzippedEgg(package_path):
@@ -69,8 +69,9 @@ def distributionForPackage(package):
 
 def distributionForDottedName(package_dottedname):
     """
-    This function is ugly and probably slow.
-    It needs to be heavily commented, it needs narrative doctests, and it needs some broad explanation.
+    This function is ugly and probably slow. It needs to be heavily
+    commented, it needs narrative doctests, and it needs some broad
+    explanation. It fails in some namespace cases (see utils.txt).
     Then it needs to be profiled.
     """
     valid_dists_for_package = []
@@ -89,9 +90,9 @@ def distributionForDottedName(package_dottedname):
 
     if len(valid_dists_for_package) == 0:
         raise LookupError("No distributions found for package `%s`; are you sure it is importable?" % package_dottedname)
-    
+
     if len(valid_dists_for_package) > 1:
-        non_namespaced_dists = filter(lambda x: len(x[1]) is 0, valid_dists_for_package)
+        non_namespaced_dists = list(filter(lambda x: len(x[1]) is 0, valid_dists_for_package))
         if len(non_namespaced_dists) == 0:
             # if we only have namespace packages at this point, 'foo.bar' and 'foo.baz', while looking for 'foo',
             # we can just select the first because the choice has no effect
@@ -126,7 +127,7 @@ def namespaceDottedNames(dist):
     except KeyError:
         ns_dottednames = []
     return ns_dottednames
-    
+
 def isUnzippedEgg(path):
     """
     Check whether a filesystem path points to an unzipped egg; z3c.autoinclude

--- a/src/z3c/autoinclude/utils.py
+++ b/src/z3c/autoinclude/utils.py
@@ -92,7 +92,7 @@ def distributionForDottedName(package_dottedname):
         raise LookupError("No distributions found for package `%s`; are you sure it is importable?" % package_dottedname)
 
     if len(valid_dists_for_package) > 1:
-        non_namespaced_dists = list(filter(lambda x: len(x[1]) is 0, valid_dists_for_package))
+        non_namespaced_dists = [x for x in valid_dists_for_package if x[1] is 0]
         if len(non_namespaced_dists) == 0:
             # if we only have namespace packages at this point, 'foo.bar' and 'foo.baz', while looking for 'foo',
             # we can just select the first because the choice has no effect

--- a/src/z3c/autoinclude/utils.txt
+++ b/src/z3c/autoinclude/utils.txt
@@ -6,13 +6,13 @@ distributionForPackage is a function that takes a module object
 and returns the setuptools distribution object that contains
 the module.
 
-It *should* find the correct distribution for a package whose namespace
-is extended by other packages in the environment. However it does *not*::
+It should find the correct distribution for a package whose namespace
+is extended by other packages in the environment::
 
     >>> from z3c.autoinclude.utils import distributionForPackage
     >>> import base2
     >>> distributionForPackage(base2)
-    base2-plug 0.0 (...base2_plug-0.0...egg)
+    base2 0.0 (...base2-0.0...egg)
 
 It should also find the correct distribution for namespace packages,
 even if the namespace being extended is a module defined in another

--- a/src/z3c/autoinclude/utils.txt
+++ b/src/z3c/autoinclude/utils.txt
@@ -6,13 +6,13 @@ distributionForPackage is a function that takes a module object
 and returns the setuptools distribution object that contains
 the module.
 
-It should find the correct distribution for a package whose namespace
-is extended by other packages in the environment::
+It *should* find the correct distribution for a package whose namespace
+is extended by other packages in the environment. However it does *not*::
 
     >>> from z3c.autoinclude.utils import distributionForPackage
     >>> import base2
     >>> distributionForPackage(base2)
-    base2 0.0 (...base2-0.0...egg)
+    base2-plug 0.0 (...base2_plug-0.0...egg)
 
 It should also find the correct distribution for namespace packages,
 even if the namespace being extended is a module defined in another
@@ -27,7 +27,7 @@ by having been extended by nested packages) it should find a package::
 
     >>> import enolp
     >>> distributionForPackage(enolp)
-    enolp.ppa.foo 0.1 (...enolp.ppa.foo-0.1...egg)
+    enolp.ppa.bar 0.1 (...enolp.ppa.bar-0.1...egg)
 
 While we're at it, it should also find the correct distribution for
 packages whose distribution name has no bearing on the name of the

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27
+    py27, pypy, py34, py35
 
 [testenv]
 deps =


### PR DESCRIPTION
This was almost entirely test changes.

There was one syntax change, one import change, and one
generator-to-list change. Plus some whitespace cleanup.

There is one test in utils.txt that was broken on both Python 2 and
Python 3; I kluged up a "fix" but the functionality seems broken in all
versions currently.