### PR TITLE
Catch and ignore AttributeError for module.__file__.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist/
 *.egg-info/
 .tox/
 !.gitattributes
+!.gitkeep

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Catch and ignore AttributeError for ``module.__file__``.
+  Fixes `issue 6 <https://github.com/zopefoundation/z3c.autoinclude/issues/6>`_.
+  [maurits]
 
 
 0.3.8 (2018-11-04)

--- a/src/z3c/autoinclude/dependency.py
+++ b/src/z3c/autoinclude/dependency.py
@@ -7,6 +7,10 @@ from pkg_resources import get_distribution
 from z3c.autoinclude.utils import DistributionManager
 from z3c.autoinclude.utils import ZCMLInfo
 
+
+logger = logging.getLogger("z3c.autoinclude")
+
+
 class DependencyFinder(DistributionManager):
 
     def includableInfo(self, zcml_to_look_for):
@@ -25,12 +29,17 @@ class DependencyFinder(DistributionManager):
                 try:
                     module = resolve(dotted_name)
                 except ImportError as exc:
-                    logging.getLogger("z3c.autoinclude").warn(
+                    logger.warning(
                         "resolve(%r) raised import error: %s" % (dotted_name, exc))
+                    continue
+                module_file = getattr(module, '__file__', None)
+                if module_file is None:
+                    logger.warning(
+                        "%r has no __file__ attribute" % dotted_name)
                     continue
                 for candidate in zcml_to_look_for:
                     candidate_path = os.path.join(
-                        os.path.dirname(module.__file__), candidate)
+                        os.path.dirname(module_file), candidate)
                     if os.path.isfile(candidate_path):
                         result[candidate].append(dotted_name)
         return result

--- a/src/z3c/autoinclude/dependency.txt
+++ b/src/z3c/autoinclude/dependency.txt
@@ -165,7 +165,7 @@ This is easiest to test by some hacking.
     >>> DistributionManager.orig_dottedNames = DistributionManager.dottedNames
     >>> def dottedNames(self):
     ...     result = self.orig_dottedNames()
-    ...     result.extend(['z3c.autoinclude.tests.empty', 'nosuchpackage'])
+    ...     result.extend(['z3c.autoinclude.tests.nomodulefile', 'nosuchpackage'])
     ...     return result
     >>> DistributionManager.dottedNames = dottedNames
     >>> pprint(b_include_finder.includableInfo(['configure.zcml',

--- a/src/z3c/autoinclude/dependency.txt
+++ b/src/z3c/autoinclude/dependency.txt
@@ -155,3 +155,24 @@ Note that it will not catch DistributionNotFound errors::
      Traceback (most recent call last):
      ...
      DistributionNotFound: ...
+
+We do not want to break when there are problems with some dependencies.
+If a dependency is not found or is not a module, we should not try to load its zcml.
+See https://github.com/zopefoundation/z3c.autoinclude/issues/6.
+This is easiest to test by some hacking.
+
+    >>> from z3c.autoinclude.utils import DistributionManager
+    >>> DistributionManager.orig_dottedNames = DistributionManager.dottedNames
+    >>> def dottedNames(self):
+    ...     result = self.orig_dottedNames()
+    ...     result.extend(['z3c.autoinclude.tests.empty', 'nosuchpackage'])
+    ...     return result
+    >>> DistributionManager.dottedNames = dottedNames
+    >>> pprint(b_include_finder.includableInfo(['configure.zcml',
+    ...                                         'meta.zcml']))
+    {'configure.zcml': ['F.H'], 'meta.zcml': ['testdirective', 'F.G', 'F.H']}
+
+Restore the original dottedNames method:
+
+    >>> DistributionManager.dottedNames = DistributionManager.orig_dottedNames
+    >>> del DistributionManager.orig_dottedNames

--- a/src/z3c/autoinclude/tests/empty/.gitkeep
+++ b/src/z3c/autoinclude/tests/empty/.gitkeep
@@ -1,3 +1,0 @@
-This directory is used in a test in dependency.txt.
-We needed a package there that is not a module,
-so without an __init__.py.

--- a/src/z3c/autoinclude/tests/empty/.gitkeep
+++ b/src/z3c/autoinclude/tests/empty/.gitkeep
@@ -1,0 +1,3 @@
+This directory is used in a test in dependency.txt.
+We needed a package there that is not a module,
+so without an __init__.py.

--- a/src/z3c/autoinclude/tests/nomodulefile/__init__.py
+++ b/src/z3c/autoinclude/tests/nomodulefile/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# This directory is used in a test in dependency.txt.
+# We need a package with a module that has no __file__ attribute.
+# This can happen in corner cases, for example with 'backports' on Python 2.7.
+# See https://github.com/zopefoundation/z3c.autoinclude/issues/6.
+del __file__


### PR DESCRIPTION
Fixes https://github.com/zopefoundation/z3c.autoinclude/issues/6.