### PR TITLE
Run the black code editor once on the code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,13 @@ from setuptools import setup, find_packages
 version = '0.3.10.dev0'
 __version__ = version
 
-TESTS_REQUIRE = [
-    "zc.buildout",
-    "zope.testing",
-]
+TESTS_REQUIRE = ["zc.buildout", "zope.testing"]
 
 setup(
     name='z3c.autoinclude',
     version=__version__,
     description="Automatically include ZCML",
-    long_description=(open('README.rst').read() + "\n" +
-                      open('CHANGES.rst').read()),
+    long_description=(open('README.rst').read() + "\n" + open('CHANGES.rst').read()),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Zope :: 3",
@@ -45,9 +41,7 @@ setup(
         'zc.buildout',
     ],
     tests_require=TESTS_REQUIRE,
-    extras_require={
-        'test': TESTS_REQUIRE,
-    },
+    extras_require={'test': TESTS_REQUIRE},
     entry_points="""
     [console_scripts]
     autoinclude-test = z3c.autoinclude.tests.tests:interactive_testing_env

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,7 +1,9 @@
 # this is a namespace package
 try:
     import pkg_resources
+
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
+
     __path__ = pkgutil.extend_path(__path__, __name__)

--- a/src/z3c/autoinclude/api.py
+++ b/src/z3c/autoinclude/api.py
@@ -3,16 +3,26 @@ import os
 DEP_KEY = 'Z3C_AUTOINCLUDE_DEPENDENCIES_DISABLED'
 PLUGIN_KEY = 'Z3C_AUTOINCLUDE_PLUGINS_DISABLED'
 
+
 def dependencies_disabled():
     return DEP_KEY in os.environ
+
+
 def disable_dependencies():
     os.environ[DEP_KEY] = 'True'
+
+
 def enable_dependencies():
     del os.environ[DEP_KEY]
 
+
 def plugins_disabled():
     return PLUGIN_KEY in os.environ
+
+
 def disable_plugins():
     os.environ[PLUGIN_KEY] = 'True'
+
+
 def enable_plugins():
     del os.environ[PLUGIN_KEY]

--- a/src/z3c/autoinclude/dependency.py
+++ b/src/z3c/autoinclude/dependency.py
@@ -12,7 +12,6 @@ logger = logging.getLogger("z3c.autoinclude")
 
 
 class DependencyFinder(DistributionManager):
-
     def includableInfo(self, zcml_to_look_for):
         """Return the packages in the dependencies which are includable.
 
@@ -30,19 +29,21 @@ class DependencyFinder(DistributionManager):
                     module = resolve(dotted_name)
                 except ImportError as exc:
                     logger.warning(
-                        "resolve(%r) raised import error: %s" % (dotted_name, exc))
+                        "resolve(%r) raised import error: %s" % (dotted_name, exc)
+                    )
                     continue
                 module_file = getattr(module, '__file__', None)
                 if module_file is None:
-                    logger.warning(
-                        "%r has no __file__ attribute" % dotted_name)
+                    logger.warning("%r has no __file__ attribute" % dotted_name)
                     continue
                 for candidate in zcml_to_look_for:
                     candidate_path = os.path.join(
-                        os.path.dirname(module_file), candidate)
+                        os.path.dirname(module_file), candidate
+                    )
                     if os.path.isfile(candidate_path):
                         result[candidate].append(dotted_name)
         return result
+
 
 def package_includes(project_name, zcml_filenames=None):
     """

--- a/src/z3c/autoinclude/plugin.py
+++ b/src/z3c/autoinclude/plugin.py
@@ -26,10 +26,11 @@ def find_plugins(dotted_name):
         if ep.module_name == dotted_name:
             yield ep.dist
 
+
 def zcml_to_include(dotted_name, zcmlgroups=None):
     if zcmlgroups is None:
         zcmlgroups = ('meta.zcml', 'configure.zcml', 'overrides.zcml')
-    
+
     includable_info = []
 
     for zcmlgroup in zcmlgroups:

--- a/src/z3c/autoinclude/tests/APackage/setup.py
+++ b/src/z3c/autoinclude/tests/APackage/setup.py
@@ -3,27 +3,24 @@ import sys, os
 
 version = '0.0'
 
-setup(name='APackage',
-      version=version,
-      description="",
-      long_description="""\
+setup(
+    name='APackage',
+    version=version,
+    description="",
+    long_description="""\
 """,
-      classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-      keywords='',
-      author='',
-      author_email='',
-      url='',
-      license='',
-      package_data = {'': ['*.zcml',]},
-      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-        'BCPackage',
-	'z3c.autoinclude',
-	'TestDirective',
-      ],
-      entry_points="""
+    classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    keywords='',
+    author='',
+    author_email='',
+    url='',
+    license='',
+    package_data={'': ['*.zcml']},
+    packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=['BCPackage', 'z3c.autoinclude', 'TestDirective'],
+    entry_points="""
       # -*- Entry points: -*-
       """,
-      )
+)

--- a/src/z3c/autoinclude/tests/BCPackage/b/__init__.py
+++ b/src/z3c/autoinclude/tests/BCPackage/b/__init__.py
@@ -3,4 +3,5 @@ try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
+
     __path__ = extend_path(__path__, __name__)

--- a/src/z3c/autoinclude/tests/BCPackage/b/c/__init__.py
+++ b/src/z3c/autoinclude/tests/BCPackage/b/c/__init__.py
@@ -1,2 +1,2 @@
 #
-#sanity test
+# sanity test

--- a/src/z3c/autoinclude/tests/BCPackage/setup.py
+++ b/src/z3c/autoinclude/tests/BCPackage/setup.py
@@ -2,31 +2,31 @@ from setuptools import setup, find_packages
 
 version = '0.1'
 
-setup(name='BCPackage',
-      version=version,
-      description="",
-      long_description="""\
+setup(
+    name='BCPackage',
+    version=version,
+    description="",
+    long_description="""\
 """,
-      # Get more strings from http://www.python.org/pypi?%3Aaction=list_classifiers
-      classifiers=[
-      ],
-      keywords='',
-      author='',
-      author_email='',
-      url='',
-      license='',
-      package_data = {'': ['*.zcml',]},
-      packages=find_packages(),
-      namespace_packages=['b'],
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-          'setuptools',
-	  'TestDirective',
-	  'SiblingPackage',
-          # -*- Extra requirements: -*-
-      ],
-      entry_points="""
+    # Get more strings from http://www.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[],
+    keywords='',
+    author='',
+    author_email='',
+    url='',
+    license='',
+    package_data={'': ['*.zcml']},
+    packages=find_packages(),
+    namespace_packages=['b'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        'setuptools',
+        'TestDirective',
+        'SiblingPackage',
+        # -*- Extra requirements: -*-
+    ],
+    entry_points="""
       # -*- Entry points: -*-
       """,
-      )
+)

--- a/src/z3c/autoinclude/tests/BasePackage/setup.py
+++ b/src/z3c/autoinclude/tests/BasePackage/setup.py
@@ -3,25 +3,24 @@ import sys, os
 
 version = '0.0'
 
-setup(name='BasePackage',
-      version=version,
-      description="",
-      long_description="""\
+setup(
+    name='BasePackage',
+    version=version,
+    description="",
+    long_description="""\
 """,
-      classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-      keywords='',
-      author='',
-      author_email='',
-      url='',
-      license='',
-      package_data = {'': ['*.zcml',]},
-      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-	'z3c.autoinclude',
-      ],
-      entry_points="""
+    classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    keywords='',
+    author='',
+    author_email='',
+    url='',
+    license='',
+    package_data={'': ['*.zcml']},
+    packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=['z3c.autoinclude'],
+    entry_points="""
       # -*- Entry points: -*-
       """,
-      )
+)

--- a/src/z3c/autoinclude/tests/FooPackage/setup.py
+++ b/src/z3c/autoinclude/tests/FooPackage/setup.py
@@ -3,27 +3,26 @@ import sys, os
 
 version = '0.0'
 
-setup(name='FooPackage',
-      version=version,
-      description="",
-      long_description="""\
+setup(
+    name='FooPackage',
+    version=version,
+    description="",
+    long_description="""\
 """,
-      classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-      keywords='',
-      author='',
-      author_email='',
-      url='',
-      license='',
-      package_data = {'': ['*.zcml',]},
-      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-	'z3c.autoinclude',
-      ],
-      entry_points="""
+    classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    keywords='',
+    author='',
+    author_email='',
+    url='',
+    license='',
+    package_data={'': ['*.zcml']},
+    packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=['z3c.autoinclude'],
+    entry_points="""
       # -*- Entry points: -*-
       [z3c.autoinclude.plugin]
       fleem = basepackage
       """,
-      )
+)

--- a/src/z3c/autoinclude/tests/SRCPackage/setup.py
+++ b/src/z3c/autoinclude/tests/SRCPackage/setup.py
@@ -3,28 +3,25 @@ import sys, os
 
 version = '0.0'
 
-setup(name='SRCPackage',
-      version=version,
-      description="",
-      long_description="""\
+setup(
+    name='SRCPackage',
+    version=version,
+    description="",
+    long_description="""\
 """,
-      classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-      keywords='',
-      author='',
-      author_email='',
-      url='',
-      license='',
-      package_data = {'': ['*.zcml',]},
-      packages=find_packages('src', exclude=['ez_setup', 'examples', 'tests']),
-      package_dir={'': 'src'},
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-        'BCPackage',
-	'z3c.autoinclude',
-	'TestDirective',
-      ],
-      entry_points="""
+    classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    keywords='',
+    author='',
+    author_email='',
+    url='',
+    license='',
+    package_data={'': ['*.zcml']},
+    packages=find_packages('src', exclude=['ez_setup', 'examples', 'tests']),
+    package_dir={'': 'src'},
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=['BCPackage', 'z3c.autoinclude', 'TestDirective'],
+    entry_points="""
       # -*- Entry points: -*-
       """,
-      )
+)

--- a/src/z3c/autoinclude/tests/SiblingPackage/F/__init__.py
+++ b/src/z3c/autoinclude/tests/SiblingPackage/F/__init__.py
@@ -3,4 +3,5 @@ try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
+
     __path__ = extend_path(__path__, __name__)

--- a/src/z3c/autoinclude/tests/SiblingPackage/setup.py
+++ b/src/z3c/autoinclude/tests/SiblingPackage/setup.py
@@ -2,29 +2,30 @@ from setuptools import setup, find_packages
 
 version = '0.0'
 
-setup(name='SiblingPackage',
-      version=version,
-      description="",
-      long_description="""\
+setup(
+    name='SiblingPackage',
+    version=version,
+    description="",
+    long_description="""\
 """,
-      # Get more strings from http://www.python.org/pypi?%3Aaction=list_classifiers
-      classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-      keywords='',
-      author='',
-      author_email='',
-      url='',
-      license='GPL',
-      package_data = {'': ['*.zcml',]},
-      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      namespace_packages=['F'],
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-          'setuptools',
-	  'TestDirective',
-          # -*- Extra requirements: -*-
-      ],
-      entry_points="""
+    # Get more strings from http://www.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    keywords='',
+    author='',
+    author_email='',
+    url='',
+    license='GPL',
+    package_data={'': ['*.zcml']},
+    packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+    namespace_packages=['F'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        'setuptools',
+        'TestDirective',
+        # -*- Extra requirements: -*-
+    ],
+    entry_points="""
       # -*- Entry points: -*-
       """,
-      )
+)

--- a/src/z3c/autoinclude/tests/TestDirective/setup.py
+++ b/src/z3c/autoinclude/tests/TestDirective/setup.py
@@ -3,27 +3,28 @@ import sys, os
 
 version = '0.0'
 
-setup(name='TestDirective',
-      version=version,
-      description="",
-      long_description="""\
+setup(
+    name='TestDirective',
+    version=version,
+    description="",
+    long_description="""\
 """,
-      classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-      keywords='',
-      author='',
-      author_email='',
-      url='',
-      license='',
-      package_data = {'': ['*.zcml',]},
-      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-          # -*- Extra requirements: -*-
-      ],
-      entry_points="""
+    classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    keywords='',
+    author='',
+    author_email='',
+    url='',
+    license='',
+    package_data={'': ['*.zcml']},
+    packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        # -*- Extra requirements: -*-
+    ],
+    entry_points="""
       # -*- Entry points: -*-
       [z3c.autoinclude.plugin]
       target = basepackage
       """,
-      )
+)

--- a/src/z3c/autoinclude/tests/TestDirective/testdirective/zcml.py
+++ b/src/z3c/autoinclude/tests/TestDirective/testdirective/zcml.py
@@ -3,20 +3,23 @@ from zope.schema import TextLine
 
 test_log = []
 
+
 def clear_test_log():
     while test_log:
         test_log.pop()
 
+
 class ITestDirective(Interface):
     """Auto-include any ZCML in the dependencies of this package."""
-    
+
     test_string = TextLine(
         title=u"Test package string",
         description=u"""
         Append a value to a global variable to inspect later
         """,
         required=True,
-        )
+    )
+
 
 def testDirective(_context, test_string):
     test_log.append(test_string)

--- a/src/z3c/autoinclude/tests/XYZPackage/setup.py
+++ b/src/z3c/autoinclude/tests/XYZPackage/setup.py
@@ -2,31 +2,29 @@ from setuptools import setup, find_packages
 
 version = '0.1'
 
-setup(name='XYZPackage',
-      version=version,
-      description="",
-      long_description="""\
+setup(
+    name='XYZPackage',
+    version=version,
+    description="",
+    long_description="""\
 """,
-      # Get more strings from http://www.python.org/pypi?%3Aaction=list_classifiers
-      classifiers=[
-        "Framework :: Zope3",
-        "Programming Language :: Python",
-        ],
-      keywords='',
-      author='',
-      author_email='',
-      url='',
-      license="''",
-      packages=find_packages(exclude=['ez_setup']),
-      namespace_packages=['x', 'x.y'],
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-          'setuptools',
-	  'TestDirective',
-          # -*- Extra requirements: -*-
-      ],
-      entry_points="""
+    # Get more strings from http://www.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=["Framework :: Zope3", "Programming Language :: Python"],
+    keywords='',
+    author='',
+    author_email='',
+    url='',
+    license="''",
+    packages=find_packages(exclude=['ez_setup']),
+    namespace_packages=['x', 'x.y'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        'setuptools',
+        'TestDirective',
+        # -*- Extra requirements: -*-
+    ],
+    entry_points="""
       # -*- Entry points: -*-
       """,
-      )
+)

--- a/src/z3c/autoinclude/tests/XYZPackage/x/__init__.py
+++ b/src/z3c/autoinclude/tests/XYZPackage/x/__init__.py
@@ -3,4 +3,5 @@ try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
+
     __path__ = extend_path(__path__, __name__)

--- a/src/z3c/autoinclude/tests/XYZPackage/x/y/__init__.py
+++ b/src/z3c/autoinclude/tests/XYZPackage/x/y/__init__.py
@@ -3,4 +3,5 @@ try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
+
     __path__ = extend_path(__path__, __name__)

--- a/src/z3c/autoinclude/tests/base2/base2/__init__.py
+++ b/src/z3c/autoinclude/tests/base2/base2/__init__.py
@@ -3,4 +3,5 @@ try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
+
     __path__ = extend_path(__path__, __name__)

--- a/src/z3c/autoinclude/tests/base2/setup.py
+++ b/src/z3c/autoinclude/tests/base2/setup.py
@@ -3,26 +3,25 @@ import sys, os
 
 version = '0.0'
 
-setup(name='base2',
-      version=version,
-      description="",
-      long_description="""\
+setup(
+    name='base2',
+    version=version,
+    description="",
+    long_description="""\
 """,
-      classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-      keywords='',
-      author='',
-      author_email='',
-      url='',
-      license='',
-      package_data = {'': ['*.zcml',]},
-      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      namespace_packages=['base2'],
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-	'z3c.autoinclude',
-      ],
-      entry_points="""
+    classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    keywords='',
+    author='',
+    author_email='',
+    url='',
+    license='',
+    package_data={'': ['*.zcml']},
+    packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+    namespace_packages=['base2'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=['z3c.autoinclude'],
+    entry_points="""
       # -*- Entry points: -*-
       """,
-      )
+)

--- a/src/z3c/autoinclude/tests/base2_plug/base2/__init__.py
+++ b/src/z3c/autoinclude/tests/base2_plug/base2/__init__.py
@@ -3,4 +3,5 @@ try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
+
     __path__ = extend_path(__path__, __name__)

--- a/src/z3c/autoinclude/tests/base2_plug/setup.py
+++ b/src/z3c/autoinclude/tests/base2_plug/setup.py
@@ -3,28 +3,26 @@ import sys, os
 
 version = '0.0'
 
-setup(name='base2_plug',
-      version=version,
-      description="",
-      long_description="""\
+setup(
+    name='base2_plug',
+    version=version,
+    description="",
+    long_description="""\
 """,
-      classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-      keywords='',
-      author='',
-      author_email='',
-      url='',
-      license='',
-      package_data = {'': ['*.zcml',]},
-      packages=find_packages(),
-      namespace_packages=['base2'],
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-          'setuptools',
-          'TestDirective',
-      ],
-      entry_points="""
+    classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    keywords='',
+    author='',
+    author_email='',
+    url='',
+    license='',
+    package_data={'': ['*.zcml']},
+    packages=find_packages(),
+    namespace_packages=['base2'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=['setuptools', 'TestDirective'],
+    entry_points="""
       [z3c.autoinclude.plugin]
       target = base2
       """,
-      )
+)

--- a/src/z3c/autoinclude/tests/enolp.ppa.bar/enolp/__init__.py
+++ b/src/z3c/autoinclude/tests/enolp.ppa.bar/enolp/__init__.py
@@ -3,4 +3,5 @@ try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
+
     __path__ = extend_path(__path__, __name__)

--- a/src/z3c/autoinclude/tests/enolp.ppa.bar/enolp/ppa/__init__.py
+++ b/src/z3c/autoinclude/tests/enolp.ppa.bar/enolp/ppa/__init__.py
@@ -3,4 +3,5 @@ try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
+
     __path__ = extend_path(__path__, __name__)

--- a/src/z3c/autoinclude/tests/enolp.ppa.bar/setup.py
+++ b/src/z3c/autoinclude/tests/enolp.ppa.bar/setup.py
@@ -2,31 +2,29 @@ from setuptools import setup, find_packages
 
 version = '0.1'
 
-setup(name='enolp.ppa.bar',
-      version=version,
-      description="",
-      long_description="""\
+setup(
+    name='enolp.ppa.bar',
+    version=version,
+    description="",
+    long_description="""\
 """,
-      # Get more strings from http://www.python.org/pypi?%3Aaction=list_classifiers
-      classifiers=[
-        "Framework :: Zope3",
-        "Programming Language :: Python",
-        ],
-      keywords='',
-      author='',
-      author_email='',
-      url='',
-      license="''",
-      packages=find_packages(exclude=['ez_setup']),
-      namespace_packages=['enolp', 'enolp.ppa'],
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-          'setuptools',
-	  'TestDirective',
-          # -*- Extra requirements: -*-
-      ],
-      entry_points="""
+    # Get more strings from http://www.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=["Framework :: Zope3", "Programming Language :: Python"],
+    keywords='',
+    author='',
+    author_email='',
+    url='',
+    license="''",
+    packages=find_packages(exclude=['ez_setup']),
+    namespace_packages=['enolp', 'enolp.ppa'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        'setuptools',
+        'TestDirective',
+        # -*- Extra requirements: -*-
+    ],
+    entry_points="""
       # -*- Entry points: -*-
       """,
-      )
+)

--- a/src/z3c/autoinclude/tests/enolp.ppa.foo/enolp/__init__.py
+++ b/src/z3c/autoinclude/tests/enolp.ppa.foo/enolp/__init__.py
@@ -3,4 +3,5 @@ try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
+
     __path__ = extend_path(__path__, __name__)

--- a/src/z3c/autoinclude/tests/enolp.ppa.foo/enolp/ppa/__init__.py
+++ b/src/z3c/autoinclude/tests/enolp.ppa.foo/enolp/ppa/__init__.py
@@ -3,4 +3,5 @@ try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
+
     __path__ = extend_path(__path__, __name__)

--- a/src/z3c/autoinclude/tests/enolp.ppa.foo/setup.py
+++ b/src/z3c/autoinclude/tests/enolp.ppa.foo/setup.py
@@ -2,31 +2,29 @@ from setuptools import setup, find_packages
 
 version = '0.1'
 
-setup(name='enolp.ppa.foo',
-      version=version,
-      description="",
-      long_description="""\
+setup(
+    name='enolp.ppa.foo',
+    version=version,
+    description="",
+    long_description="""\
 """,
-      # Get more strings from http://www.python.org/pypi?%3Aaction=list_classifiers
-      classifiers=[
-        "Framework :: Zope3",
-        "Programming Language :: Python",
-        ],
-      keywords='',
-      author='',
-      author_email='',
-      url='',
-      license="''",
-      packages=find_packages(exclude=['ez_setup']),
-      namespace_packages=['enolp', 'enolp.ppa'],
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-          'setuptools',
-	  'TestDirective',
-          # -*- Extra requirements: -*-
-      ],
-      entry_points="""
+    # Get more strings from http://www.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=["Framework :: Zope3", "Programming Language :: Python"],
+    keywords='',
+    author='',
+    author_email='',
+    url='',
+    license="''",
+    packages=find_packages(exclude=['ez_setup']),
+    namespace_packages=['enolp', 'enolp.ppa'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        'setuptools',
+        'TestDirective',
+        # -*- Extra requirements: -*-
+    ],
+    entry_points="""
       # -*- Entry points: -*-
       """,
-      )
+)

--- a/src/z3c/autoinclude/tests/tests.py
+++ b/src/z3c/autoinclude/tests/tests.py
@@ -13,14 +13,25 @@ projects_dir = os.path.dirname(__file__)
 # this is the list of test packages that we'll temporarily install
 # for the duration of the tests; you MUST add your test package name
 # to this list if you want it to be available for import in doctests!
-test_packages = ['APackage', 'BCPackage', 'XYZPackage',
-                 'SiblingPackage', 'BasePackage', 'FooPackage',
-                 'base2', 'base2_plug', 'TestDirective',
-                 'enolp.ppa.foo', 'enolp.ppa.bar']
+test_packages = [
+    'APackage',
+    'BCPackage',
+    'XYZPackage',
+    'SiblingPackage',
+    'BasePackage',
+    'FooPackage',
+    'base2',
+    'base2_plug',
+    'TestDirective',
+    'enolp.ppa.foo',
+    'enolp.ppa.bar',
+]
 
 
 from zc.buildout.easy_install import install
 from pkg_resources import working_set
+
+
 def install_projects(projects, target_dir):
     links = []
     for project in projects:
@@ -28,12 +39,14 @@ def install_projects(projects, target_dir):
         dist_dir = os.path.join(project_dir, 'dist')
         if os.path.isdir(dist_dir):
             testing.rmdir(dist_dir)
-        dummy = testing.system("%s setup %s bdist_egg" % (
-                os.path.join('bin', 'buildout'), project_dir))
+        dummy = testing.system(
+            "%s setup %s bdist_egg" % (os.path.join('bin', 'buildout'), project_dir)
+        )
         links.append(dist_dir)
 
-    new_working_set = install(projects, target_dir, links=links,
-                              working_set=working_set)
+    new_working_set = install(
+        projects, target_dir, links=links, working_set=working_set
+    )
 
     # we must perform a magical incantation on each distribution
     for dist in new_working_set:
@@ -45,9 +58,11 @@ def interactive_testing_env():
     """ an interactive debugger with the testing environment set up for free """
 
     import tempfile
+
     target_dir = tempfile.mkdtemp('.z3c.autoinclude.test-installs')
     install_projects(test_packages, target_dir)
     import code
+
     code.interact()
 
 
@@ -59,6 +74,7 @@ def testSetUp(test):
 
     testing.buildoutSetUp(test)
     import tempfile
+
     target_dir = tempfile.mkdtemp('.z3c.autoinclude.test-installs')
     test._old_path = list(sys.path)
     install_projects(test_packages, target_dir)
@@ -66,6 +82,7 @@ def testSetUp(test):
 
 def testTearDown(test):
     from testdirective.zcml import clear_test_log
+
     clear_test_log()
 
     testing.buildoutTearDown(test)
@@ -75,36 +92,47 @@ def testTearDown(test):
 
 IGNORECASE = doctest.register_optionflag('IGNORECASE')
 
+
 class IgnoreCaseChecker(renormalizing.RENormalizing, object):
     def __init__(self):
-        super(IgnoreCaseChecker, self).__init__([
-            # Python 3 drops the u'' prefix on unicode strings
-            (re.compile(r"u('[^']*')"), r"\1"),
-            # Python 3 adds module name to exceptions
-            (re.compile("pkg_resources.DistributionNotFound"), r"DistributionNotFound"),
-        ])
+        super(IgnoreCaseChecker, self).__init__(
+            [
+                # Python 3 drops the u'' prefix on unicode strings
+                (re.compile(r"u('[^']*')"), r"\1"),
+                # Python 3 adds module name to exceptions
+                (
+                    re.compile("pkg_resources.DistributionNotFound"),
+                    r"DistributionNotFound",
+                ),
+            ]
+        )
+
     def check_output(self, want, got, optionflags):
         if optionflags & IGNORECASE:
             want, got = want.lower(), got.lower()
-            #print repr(want), repr(got), optionflags, IGNORECASE
+            # print repr(want), repr(got), optionflags, IGNORECASE
         return super(IgnoreCaseChecker, self).check_output(want, got, optionflags)
+
 
 def test_suite():
 
     from pprint import pprint
-    suite = doctest.DocFileSuite('../utils.txt',
-                                 '../dependency.txt',
-                                 '../plugin.txt',
-                                 setUp=testSetUp,
-                                 tearDown=testTearDown,
-                                 globs={'pprint':pprint},
-                                 checker=IgnoreCaseChecker(),
-                                 optionflags=doctest.ELLIPSIS)
+
+    suite = doctest.DocFileSuite(
+        '../utils.txt',
+        '../dependency.txt',
+        '../plugin.txt',
+        setUp=testSetUp,
+        tearDown=testTearDown,
+        globs={'pprint': pprint},
+        checker=IgnoreCaseChecker(),
+        optionflags=doctest.ELLIPSIS,
+    )
 
     return unittest.TestSuite((suite,))
 
+
 if __name__ == '__main__':
     import zope.testing.testrunner
-    zope.testing.testrunner.run([
-  '--test-path', '/home/egj/z3c.autoinclude/src',
-  ])
+
+    zope.testing.testrunner.run(['--test-path', '/home/egj/z3c.autoinclude/src'])

--- a/src/z3c/autoinclude/utils.py
+++ b/src/z3c/autoinclude/utils.py
@@ -5,6 +5,7 @@ from pkg_resources import find_distributions
 from pprint import pformat
 import sys
 
+
 class DistributionManager(object):
     def __init__(self, dist):
         self.context = dist
@@ -35,6 +36,7 @@ class DistributionManager(object):
                     result.append(subpackage)
         return result
 
+
 class ZCMLInfo(dict):
     def __init__(self, zcml_to_look_for):
         dict.__init__(self)
@@ -57,6 +59,7 @@ def subpackageDottedNames(package_path, ns_dottedname=None):
                 result.append(subpackage_name)
     return sorted(result)
 
+
 def isPythonPackage(path):
     if not os.path.isdir(path):
         return False
@@ -65,9 +68,11 @@ def isPythonPackage(path):
             return True
     return False
 
+
 def distributionForPackage(package):
     package_dottedname = package.__name__
     return distributionForDottedName(package_dottedname)
+
 
 def distributionForDottedName(package_dottedname):
     """
@@ -84,19 +89,24 @@ def distributionForDottedName(package_dottedname):
                 continue
             packages = find_packages(dist.location)
             ns_packages = namespaceDottedNames(dist)
-            #if package_dottedname in ns_packages:
-                #continue
+            # if package_dottedname in ns_packages:
+            # continue
             if package_dottedname not in packages:
                 continue
             valid_dists_for_package.append((dist, ns_packages))
 
     if len(valid_dists_for_package) == 0:
-        raise LookupError("No distributions found for package `%s`; are you sure it is importable?" % package_dottedname)
+        raise LookupError(
+            "No distributions found for package `%s`; are you sure it is importable?"
+            % package_dottedname
+        )
 
     if len(valid_dists_for_package) > 1:
-        non_namespaced_dists = [(dist, ns_packages)
-                                for dist, ns_packages
-                                in valid_dists_for_package if len(ns_packages) == 0]
+        non_namespaced_dists = [
+            (dist, ns_packages)
+            for dist, ns_packages in valid_dists_for_package
+            if len(ns_packages) == 0
+        ]
         if len(non_namespaced_dists) == 0:
             # if we only have namespace packages at this point,
             # 'foo.bar' and 'foo.baz', while looking for 'foo', we can
@@ -115,7 +125,9 @@ def distributionForDottedName(package_dottedname):
 
             return valid_dists_for_package[0][0]
 
-        valid_dists_for_package = non_namespaced_dists ### if we have packages 'foo', 'foo.bar', and 'foo.baz', the correct one is 'foo'.
+        valid_dists_for_package = (
+            non_namespaced_dists
+        )  ### if we have packages 'foo', 'foo.bar', and 'foo.baz', the correct one is 'foo'.
 
         ### we really are in trouble if we get into a situation with more than one non-namespaced package at this point.
         error_msg = '''
@@ -128,10 +140,13 @@ Distributions found: %s
 '''
 
         assert len(non_namespaced_dists) == 1, error_msg % (
-            package_dottedname, package_dottedname,
-            pformat(non_namespaced_dists))
+            package_dottedname,
+            package_dottedname,
+            pformat(non_namespaced_dists),
+        )
 
     return valid_dists_for_package[0][0]
+
 
 def namespaceDottedNames(dist):
     """
@@ -145,6 +160,7 @@ def namespaceDottedNames(dist):
         ns_dottednames = []
     return ns_dottednames
 
+
 def isUnzippedEgg(path):
     """
     Check whether a filesystem path points to an unzipped egg; z3c.autoinclude
@@ -154,12 +170,15 @@ def isUnzippedEgg(path):
     """
     return os.path.isdir(path)
 
+
 ### cargo-culted from setuptools 0.6c9's __init__.py;
 #   importing setuptools is unsafe, but i can't find any
 #   way to get the information that find_packages provides
 #   using pkg_resources and i can't figure out a way to
 #   avoid needing it.
 from distutils.util import convert_path
+
+
 def find_packages(where='.', exclude=()):
     """Return a list all Python packages found within directory 'where'
 
@@ -170,16 +189,20 @@ def find_packages(where='.', exclude=()):
     'foo' itself).
     """
     out = []
-    stack=[(convert_path(where), '')]
+    stack = [(convert_path(where), '')]
     while stack:
-        where,prefix = stack.pop(0)
+        where, prefix = stack.pop(0)
         for name in os.listdir(where):
-            fn = os.path.join(where,name)
-            if ('.' not in name and os.path.isdir(fn) and
-                os.path.isfile(os.path.join(fn,'__init__.py'))
+            fn = os.path.join(where, name)
+            if (
+                '.' not in name
+                and os.path.isdir(fn)
+                and os.path.isfile(os.path.join(fn, '__init__.py'))
             ):
-                out.append(prefix+name); stack.append((fn,prefix+name+'.'))
-    for pat in list(exclude)+['ez_setup']:
+                out.append(prefix + name)
+                stack.append((fn, prefix + name + '.'))
+    for pat in list(exclude) + ['ez_setup']:
         from fnmatch import fnmatchcase
-        out = [item for item in out if not fnmatchcase(item,pat)]
+
+        out = [item for item in out if not fnmatchcase(item, pat)]
     return out

--- a/src/z3c/autoinclude/zcml.py
+++ b/src/z3c/autoinclude/zcml.py
@@ -10,7 +10,9 @@ from z3c.autoinclude.utils import distributionForPackage
 from z3c.autoinclude.plugin import PluginFinder
 
 import logging
+
 log = logging.getLogger("z3c.autoinclude")
+
 
 def includeZCMLGroup(_context, info, filename, override=False):
     includable_zcml = info[filename]
@@ -20,7 +22,12 @@ def includeZCMLGroup(_context, info, filename, override=False):
     zcml_context = repr(_context.info)
 
     for dotted_name in includable_zcml:
-        log.debug('including file %s from package %s at %s', filename, dotted_name, zcml_context)
+        log.debug(
+            'including file %s from package %s at %s',
+            filename,
+            dotted_name,
+            zcml_context,
+        )
 
     for dotted_name in includable_zcml:
         includable_package = resolve(dotted_name)
@@ -32,19 +39,23 @@ def includeZCMLGroup(_context, info, filename, override=False):
 
 class IIncludeDependenciesDirective(Interface):
     """Auto-include any ZCML in the dependencies of this package."""
-    
+
     package = GlobalObject(
         title=u"Package to auto-include for",
         description=u"""
         Auto-include all dependencies of this package.
         """,
         required=True,
-        )
+    )
+
 
 def includeDependenciesDirective(_context, package):
 
     if api.dependencies_disabled():
-        log.warn('z3c.autoinclude.dependency is disabled but is being invoked by %s' % _context.info)
+        log.warn(
+            'z3c.autoinclude.dependency is disabled but is being invoked by %s'
+            % _context.info
+        )
         return
 
     dist = distributionForPackage(package)
@@ -53,10 +64,14 @@ def includeDependenciesDirective(_context, package):
     includeZCMLGroup(_context, info, 'meta.zcml')
     includeZCMLGroup(_context, info, 'configure.zcml')
 
+
 def includeDependenciesOverridesDirective(_context, package):
 
     if api.dependencies_disabled():
-        log.warn('z3c.autoinclude.dependency is disabled but is being invoked by %s' % _context.info)
+        log.warn(
+            'z3c.autoinclude.dependency is disabled but is being invoked by %s'
+            % _context.info
+        )
         return
 
     dist = distributionForPackage(package)
@@ -73,7 +88,7 @@ class IIncludePluginsDirective(Interface):
         Auto-include all plugins to this package.
         """,
         required=True,
-        )
+    )
 
     file = NativeStringLine(
         title=u"ZCML filename to look for",
@@ -83,13 +98,16 @@ class IIncludePluginsDirective(Interface):
         (e.g. meta.zcml, configure.zcml, overrides.zcml)
         """,
         required=False,
-        )
+    )
 
 
 def includePluginsDirective(_context, package, file=None):
 
     if api.plugins_disabled():
-        log.warn('z3c.autoinclude.plugin is disabled but is being invoked by %s' % _context.info)
+        log.warn(
+            'z3c.autoinclude.plugin is disabled but is being invoked by %s'
+            % _context.info
+        )
         return
 
     dotted_name = package.__name__
@@ -103,10 +121,14 @@ def includePluginsDirective(_context, package, file=None):
     for filename in zcml_to_look_for:
         includeZCMLGroup(_context, info, filename)
 
+
 def includePluginsOverridesDirective(_context, package, file=None):
 
     if api.plugins_disabled():
-        log.warn('z3c.autoinclude.plugin is disabled but is being invoked by %s' % _context.info)
+        log.warn(
+            'z3c.autoinclude.plugin is disabled but is being invoked by %s'
+            % _context.info
+        )
         return
 
     dotted_name = package.__name__


### PR DESCRIPTION
I ran `black --skip-string-normalization` on the code. The extra option is for not changing single quotes to double quotes, so the diff is less big and less controversial. We can do that later if wanted.

In issue #8 the consensus seemed to be that we could use black once on this package, and see if we are happy with it.