### PR TITLE
First try pkg_resources.get_distribution to find a package.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,10 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- First try ``pkg_resources.get_distribution` to find a package.
+  This helps for packages installed with ``pip``.
+  See `issue 9 <https://github.com/zopefoundation/z3c.autoinclude/issues/9>`_.
+  [maurits]
 
 Bug fixes:
 


### PR DESCRIPTION
This helps for packages installed with `pip`.
See issue #9.

I *think* this is a safe change and it makes the code saner. But it does not actually help for `pip` yet. I get an error on startup when I use a package which has `includeDependencies` in its zcml:

```
...
  File "/Users/maurits/community/plone-coredev/py3/src/z3c.autoinclude/src/z3c/autoinclude/zcml.py", line 54, in includeDependenciesDirective
    includeZCMLGroup(_context, info, 'configure.zcml')
  File "/Users/maurits/community/plone-coredev/py3/src/z3c.autoinclude/src/z3c/autoinclude/zcml.py", line 30, in includeZCMLGroup
    include(_context, filename, includable_package)
  File "/Users/maurits/community/plone-coredev/py3/src/z3c.autoinclude/lib/python3.7/site-packages/zope/configuration/xmlconfig.py", line 557, in include
    processxmlfile(f, context)
  File "/Users/maurits/community/plone-coredev/py3/src/z3c.autoinclude/lib/python3.7/site-packages/zope/configuration/xmlconfig.py", line 407, in processxmlfile
    parser.parse(src)
  File "/usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7/lib/python3.7/xml/sax/expatreader.py", line 111, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7/lib/python3.7/xml/sax/xmlreader.py", line 125, in parse
    self.feed(buffer)
  File "/usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7/lib/python3.7/xml/sax/expatreader.py", line 217, in feed
    self._parser.Parse(data, isFinal)
  File "/private/tmp/python-20190709-71298-1cfqdlu/Python-3.7.4/Modules/pyexpat.c", line 417, in StartElement
  File "/usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7/lib/python3.7/xml/sax/expatreader.py", line 370, in start_element_ns
    AttributesNSImpl(newattrs, qnames))
  File "/Users/maurits/community/plone-coredev/py3/src/z3c.autoinclude/lib/python3.7/site-packages/zope/configuration/xmlconfig.py", line 268, in startElementNS
    self._handle_exception(ex, info)
  File "/Users/maurits/community/plone-coredev/py3/src/z3c.autoinclude/lib/python3.7/site-packages/zope/configuration/xmlconfig.py", line 266, in startElementNS
    self.context.begin(name, data, info)
  File "/Users/maurits/community/plone-coredev/py3/src/z3c.autoinclude/lib/python3.7/site-packages/zope/configuration/config.py", line 700, in begin
    self.stack.append(self.stack[-1].contained(__name, __data, __info))
  File "/Users/maurits/community/plone-coredev/py3/src/z3c.autoinclude/lib/python3.7/site-packages/zope/configuration/config.py", line 1234, in contained
    raise ConfigurationError("Invalid directive", name)
zope.configuration.exceptions.ConfigurationError: ('Invalid directive', 'factory')
    File "/Users/maurits/community/plone-coredev/py3/src/z3c.autoinclude/parts/instance/etc/site.zcml", line 16.2-16.23
    File "/Users/maurits/community/plone-coredev/py3/src/z3c.autoinclude/lib/python3.7/site-packages/Products/CMFPlone/configure.zcml", line 14.2-14.46
    File "/Users/maurits/community/plone-coredev/py3/src/z3c.autoinclude/lib/python3.7/site-packages/plone/app/contenttypes/configure.zcml", line 10.2-10.37
    File "/Users/maurits/community/plone-coredev/py3/src/z3c.autoinclude/lib/python3.7/site-packages/zope/intid/configure.zcml", line 7.4
```

Feel free to improve on this PR. (It does not have the `black` changes, I can easily apply them if later needed.)