### PR TITLE
Env var Z3C_AUTOINCLUDE_DEBUG: log included packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Breaking changes:
 
 New features:
 
+- When environment variable ``Z3C_AUTOINCLUDE_DEBUG`` is set,
+  log which packages are being automatically included.
+  Do this in a form that you can copy to a ``configure.zcml`` file.
+
 - Add support for Python 3.8.
 
 Bug fixes:

--- a/src/z3c/autoinclude/api.py
+++ b/src/z3c/autoinclude/api.py
@@ -2,6 +2,7 @@ import os
 
 DEP_KEY = 'Z3C_AUTOINCLUDE_DEPENDENCIES_DISABLED'
 PLUGIN_KEY = 'Z3C_AUTOINCLUDE_PLUGINS_DISABLED'
+DEBUG_KEY = 'Z3C_AUTOINCLUDE_DEBUG'
 
 
 def dependencies_disabled():
@@ -26,3 +27,15 @@ def disable_plugins():
 
 def enable_plugins():
     del os.environ[PLUGIN_KEY]
+
+
+def debug_enabled():
+    return DEBUG_KEY in os.environ
+
+
+def disable_debug():
+    os.environ[DEBUG_KEY] = 'True'
+
+
+def enable_debug():
+    del os.environ[DEBUG_KEY]

--- a/src/z3c/autoinclude/api.py
+++ b/src/z3c/autoinclude/api.py
@@ -14,7 +14,7 @@ def disable_dependencies():
 
 
 def enable_dependencies():
-    del os.environ[DEP_KEY]
+    os.environ.pop(DEP_KEY, None)
 
 
 def plugins_disabled():
@@ -26,7 +26,7 @@ def disable_plugins():
 
 
 def enable_plugins():
-    del os.environ[PLUGIN_KEY]
+    os.environ.pop(PLUGIN_KEY, None)
 
 
 def debug_enabled():
@@ -34,7 +34,7 @@ def debug_enabled():
 
 
 def disable_debug():
-    del os.environ[DEBUG_KEY]
+    os.environ.pop(DEBUG_KEY, None)
 
 
 def enable_debug():

--- a/src/z3c/autoinclude/api.py
+++ b/src/z3c/autoinclude/api.py
@@ -34,8 +34,8 @@ def debug_enabled():
 
 
 def disable_debug():
-    os.environ[DEBUG_KEY] = 'True'
+    del os.environ[DEBUG_KEY]
 
 
 def enable_debug():
-    del os.environ[DEBUG_KEY]
+    os.environ[DEBUG_KEY] = 'True'

--- a/src/z3c/autoinclude/api.txt
+++ b/src/z3c/autoinclude/api.txt
@@ -1,0 +1,71 @@
+=============
+API functions
+=============
+
+The ``api.py`` module has some helpful functions.
+
+
+Plugins
+=======
+
+We can disable and enable autoincluding the plugins::
+
+    >>> from z3c.autoinclude import api
+    >>> api.plugins_disabled()
+    False
+    >>> api.disable_plugins()
+    >>> api.plugins_disabled()
+    True
+    >>> api.disable_plugins()  # called twice to see if this breaks
+    >>> api.plugins_disabled()
+    True
+    >>> api.enable_plugins()
+    >>> api.plugins_disabled()
+    False
+    >>> api.enable_plugins()  # called twice to see if this breaks
+    >>> api.plugins_disabled()
+    False
+
+
+Dependencies
+============
+
+We can disable and enable autoincluding the dependencies::
+
+    >>> from z3c.autoinclude import api
+    >>> api.dependencies_disabled()
+    False
+    >>> api.disable_dependencies()
+    >>> api.dependencies_disabled()
+    True
+    >>> api.disable_dependencies()  # called twice to see if this breaks
+    >>> api.dependencies_disabled()
+    True
+    >>> api.enable_dependencies()
+    >>> api.dependencies_disabled()
+    False
+    >>> api.enable_dependencies()  # called twice to see if this breaks
+    >>> api.dependencies_disabled()
+    False
+
+
+Debug
+=====
+
+We can disable and enable the debug report of autoincluded packages::
+
+    >>> from z3c.autoinclude import api
+    >>> api.debug_enabled()
+    False
+    >>> api.enable_debug()
+    >>> api.debug_enabled()
+    True
+    >>> api.enable_debug()  # called twice to see if this breaks
+    >>> api.debug_enabled()
+    True
+    >>> api.disable_debug()
+    >>> api.debug_enabled()
+    False
+    >>> api.disable_debug()  # called twice to see if this breaks
+    >>> api.debug_enabled()
+    False

--- a/src/z3c/autoinclude/dependency.py
+++ b/src/z3c/autoinclude/dependency.py
@@ -4,8 +4,10 @@ from zope.dottedname.resolve import resolve
 from pkg_resources import resource_exists
 from pkg_resources import get_provider
 from pkg_resources import get_distribution
+from z3c.autoinclude.api import debug_enabled
 from z3c.autoinclude.utils import DistributionManager
 from z3c.autoinclude.utils import ZCMLInfo
+from z3c.autoinclude.utils import create_report
 
 
 logger = logging.getLogger("z3c.autoinclude")
@@ -42,6 +44,15 @@ class DependencyFinder(DistributionManager):
                     )
                     if os.path.isfile(candidate_path):
                         result[candidate].append(dotted_name)
+
+        if debug_enabled():
+            report = create_report(result)
+            if "overrides.zcml" in zcml_to_look_for:
+                report.insert(0, "includeDependenciesOverrides found in zcml of %s." % self.context.project_name)
+            else:
+                report.insert(0, "includeDependencies found in zcml of %s." % self.context.project_name)
+            logger.info("\n".join(report))
+
         return result
 
 

--- a/src/z3c/autoinclude/plugin.py
+++ b/src/z3c/autoinclude/plugin.py
@@ -1,8 +1,14 @@
+import logging
 import os
 from pkg_resources import iter_entry_points
 from pkg_resources import resource_filename
+from z3c.autoinclude.api import debug_enabled
+from z3c.autoinclude.utils import create_report
 from z3c.autoinclude.utils import DistributionManager
 from z3c.autoinclude.utils import ZCMLInfo
+
+
+logger = logging.getLogger("z3c.autoinclude")
 
 
 class PluginFinder(object):
@@ -18,6 +24,15 @@ class PluginFinder(object):
                 groups = zcml_to_include(plugin_dottedname, zcml_to_look_for)
                 for zcml_group in groups:
                     includable_info[zcml_group].append(plugin_dottedname)
+
+        if debug_enabled():
+            report = create_report(includable_info)
+            if "overrides.zcml" in zcml_to_look_for:
+                report.insert(0, "includePluginsOverrides found in zcml of %s." % self.dottedname)
+            else:
+                report.insert(0, "includePlugins found in zcml of %s." % self.dottedname)
+            logger.info("\n".join(report))
+
         return includable_info
 
 

--- a/src/z3c/autoinclude/tests/tests.py
+++ b/src/z3c/autoinclude/tests/tests.py
@@ -118,7 +118,14 @@ def test_suite():
 
     from pprint import pprint
 
-    suite = doctest.DocFileSuite(
+    simple_suite = doctest.DocFileSuite(
+        '../api.txt',
+        globs={'pprint': pprint},
+        checker=IgnoreCaseChecker(),
+        optionflags=doctest.ELLIPSIS,
+    )
+
+    advanced_suite = doctest.DocFileSuite(
         '../utils.txt',
         '../dependency.txt',
         '../plugin.txt',
@@ -129,7 +136,7 @@ def test_suite():
         optionflags=doctest.ELLIPSIS,
     )
 
-    return unittest.TestSuite((suite,))
+    return unittest.TestSuite((simple_suite, advanced_suite))
 
 
 if __name__ == '__main__':

--- a/src/z3c/autoinclude/utils.py
+++ b/src/z3c/autoinclude/utils.py
@@ -43,6 +43,15 @@ class ZCMLInfo(dict):
         for zcml_group in zcml_to_look_for:
             self[zcml_group] = []
 
+    def __bool__(self):
+        for value in self.values():
+            if value:
+                return True
+        return False
+
+    # For Python 2:
+    __nonzero__ = __bool__
+
 
 def subpackageDottedNames(package_path, ns_dottedname=None):
     # we do not look for subpackages in zipped eggs

--- a/src/z3c/autoinclude/utils.py
+++ b/src/z3c/autoinclude/utils.py
@@ -215,3 +215,29 @@ def find_packages(where='.', exclude=()):
 
         out = [item for item in out if not fnmatchcase(item, pat)]
     return out
+
+
+def create_report(info):
+    """Create a report with a list of auto included zcml."""
+    if not info:
+        # Return a comment.  Maybe someone wants to automatically include this
+        # in a zcml file, so make it a proper xml comment.
+        return ["<!-- No zcml files found to include. -->"]
+    report = []
+    # Try to report meta.zcml first.
+    filenames = info.keys()
+    meta = "meta.zcml"
+    if meta in filenames:
+        filenames.pop(filenames.index(meta))
+        filenames.insert(0, meta)
+    for filename in filenames:
+        dotted_names = info[filename]
+        for dotted_name in dotted_names:
+            if filename == "overrides.zcml":
+                line = '  <includeOverrides package="%s" file="%s" />' % (dotted_name, filename)
+            elif filename == "configure.zcml":
+                line = '  <include package="%s" />'% dotted_name
+            else:
+                line = '  <include package="%s" file="%s" />'% (dotted_name, filename)
+            report.append(line)
+    return report

--- a/src/z3c/autoinclude/utils.py
+++ b/src/z3c/autoinclude/utils.py
@@ -44,10 +44,7 @@ class ZCMLInfo(dict):
             self[zcml_group] = []
 
     def __bool__(self):
-        for value in self.values():
-            if value:
-                return True
-        return False
+        return any(self.values())
 
     # For Python 2:
     __nonzero__ = __bool__
@@ -225,7 +222,7 @@ def create_report(info):
         return ["<!-- No zcml files found to include. -->"]
     report = []
     # Try to report meta.zcml first.
-    filenames = info.keys()
+    filenames = list(info)
     meta = "meta.zcml"
     if meta in filenames:
         filenames.pop(filenames.index(meta))

--- a/src/z3c/autoinclude/utils.py
+++ b/src/z3c/autoinclude/utils.py
@@ -225,7 +225,7 @@ def create_report(info):
     filenames = list(info)
     meta = "meta.zcml"
     if meta in filenames:
-        filenames.pop(filenames.index(meta))
+        filenames.remove(meta)
         filenames.insert(0, meta)
     for filename in filenames:
         dotted_names = info[filename]

--- a/src/z3c/autoinclude/utils.txt
+++ b/src/z3c/autoinclude/utils.txt
@@ -60,6 +60,39 @@ When no values are filled in, the boolean should be False.
 
     >>> bool(info)
     False
+
+We can create a report of the auto included zcml.
+
+    >>> from z3c.autoinclude.utils import create_report
+    >>> create_report(info)
+    ['<!-- No zcml files found to include. -->']
+
+We add information:
+
     >>> info['configure.zcml'].append('sample_package')
     >>> bool(info)
     True
+    >>> create_report(info)
+    ['  <include package="sample_package" />']
+    >>> info['configure.zcml'].append('package2')
+    >>> info['meta.zcml'].append('meta_package')
+    >>> report = create_report(info)
+    >>> len(report)
+    3
+    >>> report[0]
+    '  <include package="meta_package" file="meta.zcml" />'
+    >>> report[1]
+    '  <include package="sample_package" />'
+    >>> report[2]
+    '  <include package="package2" />'
+
+We can only add known filenames:
+
+    >>> info['overrides.zcml'].append('overrides_package')
+    Traceback (most recent call last):
+    ...
+    KeyError: 'overrides.zcml'
+    >>> overrides = ZCMLInfo(['overrides.zcml'])
+    >>> overrides['overrides.zcml'].append('overrides_package')
+    >>> create_report(overrides)
+    ['  <includeOverrides package="overrides_package" file="overrides.zcml" />']

--- a/src/z3c/autoinclude/utils.txt
+++ b/src/z3c/autoinclude/utils.txt
@@ -45,3 +45,21 @@ package contained within it::
     >>> import F.G
     >>> distributionForPackage(F.G) # doctest: +IGNORECASE
     SiblingPackage 0.0 (...SiblingPackage-0.0...egg)
+
+We have a helper class ZCMLInfo which is a dictionary which automatically gets keys.
+Perhaps a defaultdict would work too now, but let's not change the class at this time.
+
+    >>> from z3c.autoinclude.utils import ZCMLInfo
+    >>> info = ZCMLInfo(['meta.zcml', 'configure.zcml'])
+    >>> sorted(info.keys())
+    ['configure.zcml', 'meta.zcml']
+    >>> list(info.values())
+    [[], []]
+
+When no values are filled in, the boolean should be False.
+
+    >>> bool(info)
+    False
+    >>> info['configure.zcml'].append('sample_package')
+    >>> bool(info)
+    True


### PR DESCRIPTION
This gives helpful output when people want to move away from autoinclude, either because of perceived slowness, or because of problems when you `pip install` everything.

Sample output in a Plone customer project when starting up Zope:

```
INFO z3c.autoinclude includePlugins found in zcml of plone.
  <include package="ftw.upgrade" file="meta.zcml" />
  <include package="five.pt" file="meta.zcml" />
  <include package="z3c.jbot" file="meta.zcml" />
  <include package="plone.app.dexterity" file="meta.zcml" />
  <include package="plone.resource" file="meta.zcml" />
...
INFO z3c.autoinclude includePlugins found in zcml of plone.
  <include package="ftw.upgrade" />
  <include package="plone4.csrffixes" />
  <include package="Products.PloneKeywordManager" />
  <include package="collective.revisionmanager" />
  <include package="five.pt" />
...
INFO z3c.autoinclude includeDependencies found in zcml of Products.PloneKeywordManager.
  <include package="plone.api" />
...
INFO z3c.autoinclude includePluginsOverrides found in zcml of plone.
  <includeOverrides package="plone.app.dexterity" file="overrides.zcml" />
```

The commits are really separate, so you can view them individually if you want to focus on one change at a time. The third commit builds on the second commit, which builds on the first commit.